### PR TITLE
Add Table of Contents to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,49 @@ It is an extremely powerful custom terminal environment built on top of [zinit](
 
 There is a significant amount of custom zsh, bash, vimL and perl code that I wrote to support very advanced functionality that I desired.
 
+## Contents
+
+- [Install Full](#full-installation-instructions-to-zpwr)
+- [Features](#zpwr-features)
+- [Dependencies](#zpwr-dependencies)
+- [Supported Operating Systems](#supported-operating-systems)
+- [ZPWR Extras Not Installed](#zpwr-extras-not-installed)
+- [Install Limited](#limited-install)
+- [Uninstall](#uninstall)
+- [Setup Step: Font](#font)
+- [Updating](#updating)
+- [Tmux Prefix Detail](#tmux-prefix) - How To
+- [Vim Autosave](#autosaving-vim-plugins) - Feature
+- [Bypass Space Expansion](#bypassing-expansion-on-space) - How To
+- [Turnin Off Ponies And Colors Globally](#turning-off-ponies-and-colors-globally) - How To
+- [Bypass Space Expansion](#bypassing-expansion-on-space) - How To
+- [Vim Language Support For Tmux Right Pane](#running-script-from-vim-in-tmux-right-pane-is-supported-for-these-languages)
+- [Main Window](#tmux-main-window) - Feature
+- [Personal Config File Information](#personal-config) - Detail
+- [zpwr-verb menu completion](#zpwr-verbs) - Feature
+- [Github Account Variable](#zpwr_github_account-variable) - Setup Step
+- [Add A New Zsh Plugin](#adding-more-zinit-plugins) - How To
+- [Configurable Environment Variables](#environment-variables) - Feature
+- [Test Suite](#tests)
+- [Super Fast Shell Startup Speed](#shell-startup-speed) - Feature
+- [Contributing](#contributing) - documentation, marketing, video tutorials, GIFs/screenshots in README and expanding the tests
+- [Warning](#warnings) - The only user modifiable files are the user token files
+- [MacbookPro Screenshots](#running-on-a-macbookpro)
+- [RasberryPie Screenshots](#running-on-the-raspberry-pi-3)
+- [Rock64 Screenshots](#running-on-the-rock64)
+- [KeyBindings](#keybindings-generated-with-source-keybindingstoreadmezsh--readmemd)
+- [Tmux Keybindings](#tmux-keybindings-tmux-lsk)
+- [Zsh Vim Insert Mode Keybindings](#zsh-vim-insert-mode-keybindings-bindkey--m-viins--l)
+- [Zsh Vim Normal Mode Keybindings](#zsh-vim-normal-mode-keybindings-bindkey--m-vicmd--l)
+- [Zsh Vim MenuSelect Mode Keybindings](#zsh-menuselect-mode-keybindings-bindkey--m-menuselect--l)
+- [Zsh Vim Visual Mode Keybindings](#zsh-vim-visual-mode-keybindings-bindkey--m-visual--l)
+- [Zsh Vim ListScroll Mode Keybindings](#zsh-listscroll-mode-keybindings-bindkey--m-listscroll--l)
+- [Zsh Vim Operator Mode Keybindings](#zsh-vim-operator-mode-keybindings-bindkey--m-viopp--l)
+- [Vim Insert Mode Keybindings](#vim-keybindings-insert-mode)
+- [Vim Normal Mode Keybindings](#vim-keybindings-normal-mode)
+- [Vim Keybindings Visual Mode](#vim-keybindings-visual-mode)
+- [Vim Keybindings Command Colon Mode](#vim-keybindings-command-colon-mode)
+
 # Full Installation Instructions to `~/.zpwr`
 
 ```sh


### PR DESCRIPTION
Zpwr has many features! Leading to an epicly large readme.
Similarly, Github Awesome presents a ton of information via Readme.

The secret to making the github awesome readme digestable is the table of contents.
Users can quickly explore the readme by clicking the table of content link and then clicking the back arrow.

1) Some sections labeled Feature, might also be named Detail.
2) Based on Github Awesomes format: https://github.com/sindresorhus/awesome/blob/main/readme.md

Happy to discuss further. Availiable via slack too. 👍

See it in action, HERE: https://github.com/MichaelDimmitt/zpwr/blob/add-readme-table-of-contents/README.md